### PR TITLE
Switched styling to use class `tooltip-js`

### DIFF
--- a/css/tooltip.css
+++ b/css/tooltip.css
@@ -2,7 +2,7 @@
  * Tooltip.js styles
  */
 
-#tooltip {
+.tooltip-js {
 	position:absolute;
 	background:#DB2A64;
 	color:#ffffff;
@@ -10,6 +10,6 @@
 	z-index:999;
 }
 
-#tooltip.alt-tooltip {
+.tooltip-js.alt-tooltip {
 	background:#490B22;
 }

--- a/js/Tooltip.js
+++ b/js/Tooltip.js
@@ -72,7 +72,9 @@
 		var options = tooltipId && _tooltips[tooltipId] && _tooltips[tooltipId].options;
 
 		if (options && options["class"]) {
-			tooltipElm.setAttribute("class", options["class"]);
+			tooltipElm.setAttribute("class", 'tooltip-js ' + options["class"]);
+		} else {
+			tooltipElm.setAttribute("class", 'tooltip-js');
 		}
 
 		tooltipElm.setAttribute("id", _options.tooltipId);


### PR DESCRIPTION
...away from styling with the id, for easier
overwriting in external stylesheets.

The id is still there, but it's a better practice to style based on classnames. 

I was going to switch the `element.setAttribute('class', 'foobar')` to the easier `element.classList.add('foobar')`, but it would have broken the current compatibility with IE9, so I matched the current code style. 